### PR TITLE
Add a page to list all future events using QuickGrid

### DIFF
--- a/BlazorEventAppWebAssembly/BlazorEventAppWebAssembly.csproj
+++ b/BlazorEventAppWebAssembly/BlazorEventAppWebAssembly.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/BlazorEventAppWebAssembly/Layout/NavMenu.razor
+++ b/BlazorEventAppWebAssembly/Layout/NavMenu.razor
@@ -24,6 +24,11 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="events">
+                <span class="bi bi-calendar-event-fill-nav-menu" aria-hidden="true"></span> Events
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/BlazorEventAppWebAssembly/Pages/Events.razor
+++ b/BlazorEventAppWebAssembly/Pages/Events.razor
@@ -1,0 +1,45 @@
+@page "/events"
+@using BlazorEventAppWebAssembly.Models
+@using Microsoft.AspNetCore.Components.QuickGrid
+
+<PageTitle>Events</PageTitle>
+
+<h1>Upcoming Events</h1>
+
+@if (events == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <QuickGrid Items="events">
+        <PropertyColumn Property="@(e => e.Name)" Title="Name" />
+        <PropertyColumn Property="@(e => e.Location)" Title="Location" />
+        <PropertyColumn Property="@(e => e.StartDate)" Title="Start Date" />
+        <PropertyColumn Property="@(e => e.EndDate)" Title="End Date" />
+        <PropertyColumn Property="@(e => e.Description)" Title="Description" />
+        <PropertyColumn Property="@(e => e.EventType)" Title="Event Type" />
+    </QuickGrid>
+}
+
+@code {
+    private List<Event>? events;
+
+    protected override void OnInitialized()
+    {
+        events = GetFutureEvents();
+    }
+
+    private List<Event> GetFutureEvents()
+    {
+        var allEvents = new List<Event>
+        {
+            new Event { Id = 1, Name = "Music Concert", Location = "New York", StartDate = DateTime.Now.AddDays(10), EndDate = DateTime.Now.AddDays(11), Description = "A great music concert.", EventType = EventType.MUSIC },
+            new Event { Id = 2, Name = "Tech Conference", Location = "San Francisco", StartDate = DateTime.Now.AddDays(20), EndDate = DateTime.Now.AddDays(22), Description = "A tech conference.", EventType = EventType.CONFERENCE },
+            new Event { Id = 3, Name = "Sports Event", Location = "Los Angeles", StartDate = DateTime.Now.AddDays(5), EndDate = DateTime.Now.AddDays(6), Description = "A sports event.", EventType = EventType.SPORTS },
+            new Event { Id = 4, Name = "Cultural Festival", Location = "Chicago", StartDate = DateTime.Now.AddDays(15), EndDate = DateTime.Now.AddDays(16), Description = "A cultural festival.", EventType = EventType.CUlTURAL }
+        };
+
+        return allEvents.Where(e => e.StartDate > DateTime.Now).ToList();
+    }
+}


### PR DESCRIPTION
Related to #1

Add a new page to list all future events using QuickGrid.

* **BlazorEventAppWebAssembly.csproj**
  - Add a package reference to `Microsoft.AspNetCore.Components.QuickGrid`.

* **Events.razor**
  - Create a new page component to list all future events.
  - Use QuickGrid to display the events.
  - Fetch events data from a static list.
  - Filter events to show only future events.

* **NavMenu.razor**
  - Add a new navigation link to the `Events` page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JohanSmarius/BlazorEventAppWebAssembly/pull/2?shareId=7f32aae2-58ab-4472-a452-962211beb386).