### PR TITLE
Enhance events table appearance

### DIFF
--- a/BlazorEventAppWebAssembly/Pages/Events.razor
+++ b/BlazorEventAppWebAssembly/Pages/Events.razor
@@ -12,13 +12,13 @@
 }
 else
 {
-    <QuickGrid Items="events.AsQueryable()" TGridItem="Event">
-        <PropertyColumn Property="@(e => e.Name)" Title="Name" />
-        <PropertyColumn Property="@(e => e.Location)" Title="Location" />
-        <PropertyColumn Property="@(e => e.StartDate)" Title="Start Date" />
-        <PropertyColumn Property="@(e => e.EndDate)" Title="End Date" />
-        <PropertyColumn Property="@(e => e.Description)" Title="Description" />
-        <PropertyColumn Property="@(e => e.EventType)" Title="Event Type" />
+    <QuickGrid Items="events.AsQueryable()" TGridItem="Event" class="table table-striped">
+        <PropertyColumn Property="@(e => e.Name)" Title="Name" class="table-header" />
+        <PropertyColumn Property="@(e => e.Location)" Title="Location" class="table-header" />
+        <PropertyColumn Property="@(e => e.StartDate)" Title="Start Date" class="table-header" />
+        <PropertyColumn Property="@(e => e.EndDate)" Title="End Date" class="table-header" />
+        <PropertyColumn Property="@(e => e.Description)" Title="Description" class="table-header" />
+        <PropertyColumn Property="@(e => e.EventType)" Title="Event Type" class="table-header" />
     </QuickGrid>
 }
 

--- a/BlazorEventAppWebAssembly/wwwroot/css/app.css
+++ b/BlazorEventAppWebAssembly/wwwroot/css/app.css
@@ -112,3 +112,37 @@ code {
 .form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
     text-align: start;
 }
+
+/* Styles for .table and .table-striped classes */
+.table {
+    width: 100%;
+    margin-bottom: 1rem;
+    color: #212529;
+    border-collapse: collapse;
+}
+
+.table th,
+.table td {
+    padding: 0.75rem;
+    vertical-align: top;
+    border-top: 1px solid #dee2e6;
+}
+
+.table thead th {
+    vertical-align: bottom;
+    border-bottom: 2px solid #dee2e6;
+}
+
+.table tbody + tbody {
+    border-top: 2px solid #dee2e6;
+}
+
+.table-striped tbody tr:nth-of-type(odd) {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+/* Styles for .table-header class */
+.table-header {
+    background-color: #f8f9fa;
+    font-weight: bold;
+}


### PR DESCRIPTION
Related to #3

Update `Events.razor` and `app.css` to make the table of events look more like a traditional table.

* **Events.razor**
  - Add `class="table table-striped"` to the `QuickGrid` component.
  - Add `class="table-header"` to the `PropertyColumn` components.

* **app.css**
  - Add styles for `.table` and `.table-striped` classes.
  - Add styles for `.table-header` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JohanSmarius/BlazorEventAppWebAssembly/pull/4?shareId=739d9b8d-8afe-49af-9c4a-329249174d43).