### PR TITLE
Add time to event start and end dates

### DIFF
--- a/BlazorEventAppWebAssembly/Pages/AddEvent.razor
+++ b/BlazorEventAppWebAssembly/Pages/AddEvent.razor
@@ -20,12 +20,12 @@
         <InputText id="location" class="form-control" @bind-Value="newEvent.Location" />
     </div>
     <div class="mb-3">
-        <label for="startDate" class="form-label">Start Date</label>
-        <InputDate id="startDate" class="form-control" @bind-Value="newEvent.StartDate" />
+        <label for="startDate" class="form-label">Start Date and Time</label>
+        <InputDateTime id="startDate" class="form-control" @bind-Value="newEvent.StartDate" />
     </div>
     <div class="mb-3">
-        <label for="endDate" class="form-label">End Date</label>
-        <InputDate id="endDate" class="form-control" @bind-Value="newEvent.EndDate" />
+        <label for="endDate" class="form-label">End Date and Time</label>
+        <InputDateTime id="endDate" class="form-control" @bind-Value="newEvent.EndDate" />
     </div>
     <div class="mb-3">
         <label for="description" class="form-label">Description</label>

--- a/BlazorEventAppWebAssembly/Pages/Events.razor
+++ b/BlazorEventAppWebAssembly/Pages/Events.razor
@@ -20,8 +20,8 @@ else
     <QuickGrid Items="events.AsQueryable()" TGridItem="Event" >
         <PropertyColumn Property="@(e => e.Name)" Title="Name" Sortable="true"/>
         <PropertyColumn Property="@(e => e.Location)" Title="Location" Sortable="true"/>
-        <PropertyColumn Property="@(e => e.StartDate)" Title="Start Date" Sortable="true" />
-        <PropertyColumn Property="@(e => e.EndDate)" Title="End Date" Sortable="true" />
+        <PropertyColumn Property="@(e => e.StartDate.ToString("g"))" Title="Start Date" Sortable="true" />
+        <PropertyColumn Property="@(e => e.EndDate.ToString("g"))" Title="End Date" Sortable="true" />
         <PropertyColumn Property="@(e => e.Description)" Title="Description" Sortable="true" />
         <PropertyColumn Property="@(e => e.EventType)" Title="Event Type" Sortable="true" />
     </QuickGrid>


### PR DESCRIPTION
Related to #7

Add time input for event start and end dates.

* Replace `InputDate` components with `InputDateTime` components in `BlazorEventAppWebAssembly/Pages/AddEvent.razor` to allow time input for `StartDate` and `EndDate`.
* Update `BlazorEventAppWebAssembly/Pages/Events.razor` to display `StartDate` and `EndDate` with time part using `ToString("g")`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JohanSmarius/BlazorEventAppWebAssembly/pull/8?shareId=f7f7dc19-c146-46c3-a5f2-e3355c949937).