### PR TITLE
Add validation for event dates

### DIFF
--- a/BlazorEventAppWebAssembly/Models/Event.cs
+++ b/BlazorEventAppWebAssembly/Models/Event.cs
@@ -1,6 +1,6 @@
 ﻿namespace BlazorEventAppWebAssembly.Models
 {
-    public class Event
+    public class Event : IValidatableObject
     {
         public int Id { get; set; }
 
@@ -15,5 +15,22 @@
         public string Description { get; set; }
 
         public EventType EventType { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            var errors = new List<ValidationResult>();
+
+            if (EndDate <= StartDate)
+            {
+                errors.Add(new ValidationResult("End date must be later than start date.", new[] { nameof(EndDate) }));
+            }
+
+            if ((EndDate - StartDate).TotalHours < 2)
+            {
+                errors.Add(new ValidationResult("There must be at least a 2-hour difference between start date and end date.", new[] { nameof(EndDate), nameof(StartDate) }));
+            }
+
+            return errors;
+        }
     }
 }

--- a/BlazorEventAppWebAssembly/Pages/AddEvent.razor
+++ b/BlazorEventAppWebAssembly/Pages/AddEvent.razor
@@ -8,6 +8,18 @@
 
 <h3>Add a New Event</h3>
 
+@if (validationErrors != null && validationErrors.Any())
+{
+    <div class="alert alert-danger">
+        <ul>
+            @foreach (var error in validationErrors)
+            {
+                <li>@error</li>
+            }
+        </ul>
+    </div>
+}
+
 <EditForm Model="@newEvent" OnValidSubmit="HandleValidSubmit">
     <DataAnnotationsValidator />
     <ValidationSummary />
@@ -47,9 +59,20 @@
 
 @code {
     private Event newEvent = new Event();
+    private List<string> validationErrors = new List<string>();
 
     private async Task HandleValidSubmit()
     {
+        var context = new ValidationContext(newEvent);
+        var results = new List<ValidationResult>();
+        validationErrors.Clear();
+
+        if (!Validator.TryValidateObject(newEvent, context, results, true))
+        {
+            validationErrors.AddRange(results.Select(r => r.ErrorMessage));
+            return;
+        }
+
         await EventService.AddEvent(newEvent);
         newEvent = new Event();
         Navigation.NavigateTo("/events");


### PR DESCRIPTION
Related to #9

Implement validation for `EndDate` and `StartDate` in the `Event` class and update the `AddEvent` form to display validation errors.

* Implement `IValidatableObject` interface in `Event` class.
* Add `Validate` method to `Event` class to ensure `EndDate` is later than `StartDate` and at least 2 hours apart.
* Update `AddEvent` form to call `newEvent.Validate` and display validation errors if any.
* Add a `validationErrors` field to store validation errors.
* Add a section to display validation errors in the form.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JohanSmarius/BlazorEventAppWebAssembly/pull/10?shareId=55df2584-db68-4c4b-904a-c6a0a95c6e07).